### PR TITLE
Fix physio paths and Linux/Windows cpulse mismatch 

### DIFF
--- a/code/readin/tapas_physio_write2bids.m
+++ b/code/readin/tapas_physio_write2bids.m
@@ -43,7 +43,7 @@ function [] = tapas_physio_write2bids(ons_secs, write_bids, log_files)
 % see the file COPYING or <http://www.gnu.org/licenses/>.
 
 bids_step = write_bids.bids_step;
-bids_dir = write_bids.bids_dir{1};
+bids_dir = write_bids.bids_dir;
 bids_prefix = write_bids.bids_prefix;
 
 cardiac = ons_secs.c;

--- a/code/tapas_physio_new.m
+++ b/code/tapas_physio_new.m
@@ -91,7 +91,7 @@ else
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     
     % Overarching directory, relative to which output files are saved
-    save_dir = {'physio_out'};
+    save_dir = 'physio_out';
     
     
     
@@ -767,8 +767,8 @@ end
 %                                   pulse detection)write_bids.bids_step =
 %                                   4 (DEFAULT);
 write_bids.bids_step            = 4;
-write_bids.bids_dir             = {'physio_out'};   % output file of file, default = 'physio_out'
-write_bids.bids_prefix          = '';               % BIDS prefix
+write_bids.bids_dir             = 'physio_out';   % output director for BIDS converted files, default = 'physio_out'
+write_bids.bids_prefix          = '';             % BIDS prefix
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/code/utils/tapas_physio_cell2char.m
+++ b/code/utils/tapas_physio_cell2char.m
@@ -23,6 +23,7 @@ function physio = tapas_physio_cell2char(physio)
 % COPYING or <http://www.gnu.org/licenses/>.
 
 
+physio.write_bids.bids_dir = char(physio.write_bids.bids_dir);
 physio.save_dir = char(physio.save_dir);
 physio.log_files.cardiac = char(physio.log_files.cardiac);
 physio.log_files.respiration = char(physio.log_files.respiration);

--- a/code/utils/tapas_physio_fill_empty_parameters.m
+++ b/code/utils/tapas_physio_fill_empty_parameters.m
@@ -74,6 +74,6 @@ end
 % if no specific directory is given for BIDS output, write files to where
 % other PhysIO output is written to
 if isempty(physio.write_bids.bids_dir) || ...
-        (iscell(physio.write_bids.bids_dir) && isempty(physio.write_bids.bids_dir{1}))
+        (iscell(physio.write_bids.bids_dir) && isempty([physio.write_bids.bids_dir{:}]))
     physio.write_bids.bids_dir = physio.save_dir;
 end

--- a/code/utils/tapas_physio_prepend_absolute_paths.m
+++ b/code/utils/tapas_physio_prepend_absolute_paths.m
@@ -39,14 +39,22 @@ if (isempty(parentPath) || ( iscell(parentPath) && isempty([parentPath{:}]))) &&
 end
 
 %% update all affected relative file names with save_dir
-save_dir = physio.save_dir;
 
-if ~exist(save_dir, 'dir') && ~isempty(save_dir)
-    [status,msg,msgID] = mkdir(save_dir);
-    if ~status % unsuccessful creation AND directory did not exist before
-       physio.verbose = tapas_physio_log(msg, physio.verbose, 2);
+requiredDirs = {physio.save_dir, physio.write_bids.bids_dir};
+
+for iRequiredDirs = 1:numel(requiredDirs)
+
+    required_dir = requiredDirs{iRequiredDirs};
+
+    if ~exist(required_dir, 'dir') && ~isempty(required_dir)
+        [status,msg,msgID] = mkdir(required_dir);
+        if ~status % unsuccessful creation AND directory did not exist before
+            physio.verbose = tapas_physio_log(msg, physio.verbose, 2);
+        end
     end
 end
+
+save_dir = physio.save_dir;
 
 if ~isequal(save_dir, fileparts(physio.verbose.fig_output_file))
     physio.verbose.fig_output_file = fullfile(save_dir, ...

--- a/code/utils/tapas_physio_prepend_absolute_paths.m
+++ b/code/utils/tapas_physio_prepend_absolute_paths.m
@@ -27,15 +27,15 @@ function physio = tapas_physio_prepend_absolute_paths(physio)
 
 %% Make all folders in physio struct absolute
 % only relative folder for save_dir specified, make absolute
-if isempty(parentPath) && ~isempty(currentFolder)
+if (isempty(parentPath) || ( iscell(parentPath) && isempty([parentPath{:}]))) && ~isempty(currentFolder)
     physio.save_dir = fullfile(pwd, physio.save_dir);
 end
 
 [parentPath, currentFolder] = fileparts(physio.write_bids.bids_dir);
 
 % only relative folder specified, make absolute
-if isempty(parentPath) && ~isempty(currentFolder)
-    physio.save_dir = fullfile(pwd, physio.save_dir);
+if (isempty(parentPath) || ( iscell(parentPath) && isempty([parentPath{:}]))) && ~isempty(currentFolder)
+    physio.write_bids.bids_dir = fullfile(pwd, physio.write_bids.bids_dir);
 end
 
 %% update all affected relative file names with save_dir

--- a/tests/unit/readin/tapas_physio_readin_bids_test.m
+++ b/tests/unit/readin/tapas_physio_readin_bids_test.m
@@ -238,7 +238,7 @@ switch physio.write_bids.bids_step
 end
 bids_prefix = physio.write_bids.bids_prefix;
 tsvFilename = sprintf('%2$s_desc-%1$s_physio.tsv',tag, bids_prefix);
-
+[~,bids_dir] = fileparts(physio.write_bids.bids_dir{1});
 actualTsvFile = fullfile(pathCurrentExample, bids_dir, ...
     tsvFilename);
 

--- a/tests/unit/readin/tapas_physio_readin_bids_test.m
+++ b/tests/unit/readin/tapas_physio_readin_bids_test.m
@@ -177,8 +177,7 @@ switch physio.write_bids.bids_step
 end
 bids_prefix = physio.write_bids.bids_prefix;
 jsonFilename = sprintf('%2$s_desc-%1$s_physio.json',tag, bids_prefix);
-[~,bids_dir] = fileparts(physio.write_bids.bids_dir{1});
-actualJsonFile = fullfile(pathCurrentExample, bids_dir , ...
+actualJsonFile = fullfile(physio.write_bids.bids_dir, ...
     jsonFilename);
 
 str = fileread(actualJsonFile); % dedicated for reading files as text
@@ -238,8 +237,7 @@ switch physio.write_bids.bids_step
 end
 bids_prefix = physio.write_bids.bids_prefix;
 tsvFilename = sprintf('%2$s_desc-%1$s_physio.tsv',tag, bids_prefix);
-[~,bids_dir] = fileparts(physio.write_bids.bids_dir{1});
-actualTsvFile = fullfile(pathCurrentExample, bids_dir, ...
+actualTsvFile = fullfile(physio.write_bids.bids_dir, ...
     tsvFilename);
 
 % unzip compressed tab-separated values file and read into matlab variable

--- a/tests/unit/readin/tapas_physio_readin_bids_test.m
+++ b/tests/unit/readin/tapas_physio_readin_bids_test.m
@@ -177,7 +177,8 @@ switch physio.write_bids.bids_step
 end
 bids_prefix = physio.write_bids.bids_prefix;
 jsonFilename = sprintf('%2$s_desc-%1$s_physio.json',tag, bids_prefix);
-actualJsonFile = fullfile(pathCurrentExample, physio.write_bids.bids_dir{1}, ...
+[~,bids_dir] = fileparts(physio.write_bids.bids_dir{1});
+actualJsonFile = fullfile(pathCurrentExample, bids_dir , ...
     jsonFilename);
 
 str = fileread(actualJsonFile); % dedicated for reading files as text
@@ -238,7 +239,7 @@ end
 bids_prefix = physio.write_bids.bids_prefix;
 tsvFilename = sprintf('%2$s_desc-%1$s_physio.tsv',tag, bids_prefix);
 
-actualTsvFile = fullfile(pathCurrentExample, physio.write_bids.bids_dir{1}, ...
+actualTsvFile = fullfile(pathCurrentExample, bids_dir, ...
     tsvFilename);
 
 % unzip compressed tab-separated values file and read into matlab variable


### PR DESCRIPTION
- due to numerical instability of our accelerated `tapas_physio_corrcoef12` function, different number of `cpulse` cardiac pulse events were detected for near-constant portions of the cardiac traces
- we ignore too small variance values for scaling of the correlation coefficient and set them to NaN