### PR TITLE
removed wikidocs submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "wikidocs"]
-	path = wikidocs
-	url = https://gitlab.ethz.ch/physio/physio-doc.wiki.git
-	branch = master


### PR DESCRIPTION
- Wiki still lives [here](https://github.com/ComputationalPsychiatry/PhysIO/wiki), but removed recursive checkout to `wikidocs` subfolder