### PR TITLE
Add a complete unit and integration test entry point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,21 +248,27 @@ motion parameter regressors.
 Tests use the **MATLAB unit testing framework** (`matlab.unittest`).
 
 ```matlab
-% Run all unit tests
-cd tests/unit
-results = runtests('.');
-
-% Run all integration tests (requires downloaded example data)
-cd tests/integration
-results = runtests('.');
+% Run all unit and integration tests (recommended single entry point)
+testResults = tapas_physio_run_all_tests();
 ```
 
-Integration tests compare pipeline output against reference data stored in
-`test-reference-results/` subfolder (from different repository, see note above). 
+The runner discovers tests recursively, verifies the required example and reference
+data, and downloads the version-matched datasets from Zenodo when they are missing.
+It runs both suites and raises an error if any test fails or is incomplete. Run it
+from the PhysIO repository with PhysIO and SPM initialized on the MATLAB path.
+
+Do not use `cd tests/unit; runtests('.')` as the complete unit-test command: it does
+not recurse into the category subfolders and can therefore report zero tests.
+
+Integration tests compare pipeline output against reference data stored in the
+`test-reference-results/` subfolder (from a different repository; see note above).
 When adding a new example or fixing a bug that legitimately changes output, 
 update the reference results accordingly.
 
 Both SPM Batch Editor and MATLAB-only code paths are tested for all examples.
+
+All unit and integration tests must complete successfully before a pull request is
+marked ready for review. Keep a pull request in draft state while tests are failing.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Installation
 Getting Started
 ---------------
 
-1. Download the PhysIO examples via running `tapas_download_physio_example_data()` (located in the `<PHYSIO_PATH>` main folder)
+1. Download the PhysIO examples via running `tapas_physio_download_example_data()` (located in the `<PHYSIO_PATH>` main folder)
     - The PhysIO Example files will be downloaded to `<PHYSIO_PATH>/examples`
 2. Run `siemens_vb_ppu3t_sync_first_matlab_script.m` in subdirectory `Siemens_VB/PPU3T_Sync_First`
 3. See the next two sections of this document for more help and documentation.

--- a/tests/tapas_physio_get_path_examples.m
+++ b/tests/tapas_physio_get_path_examples.m
@@ -75,15 +75,13 @@ end
 pathExamples = tapas_physio_simplify_path(pathExamples);
 
 if doDownloadData && (doVerifyPath && ~haveFoundPath)
-    pathExamples = tapas_physio_download_example_data();
-end
-
-if (doVerifyPath && ~haveFoundPath)
-    if doDownloadData
-        pathExamples = tapas_physio_download_test_reference_results();
-    else
-        physio = tapas_physio_new();
-        tapas_physio_log('No PhysIO examples data found. Please download via tapas_physio_download_example_data()', physio.verbose, 2);
-    end
+    tapas_physio_download_example_data();
+    % Verify the downloaded data without triggering another download.
+    pathExamples = tapas_physio_get_path_examples(pathPhysioPublic, ...
+        doVerifyPath, false);
+elseif doVerifyPath && ~haveFoundPath
+    physio = tapas_physio_new();
+    tapas_physio_log(['No PhysIO examples data found. Please download ' ...
+        'via tapas_physio_download_example_data()'], physio.verbose, 2);
 end
 

--- a/tests/tapas_physio_run_all_tests.m
+++ b/tests/tapas_physio_run_all_tests.m
@@ -1,0 +1,60 @@
+function testResults = tapas_physio_run_all_tests()
+% Run the complete PhysIO unit and integration test suites.
+%
+%   testResults = tapas_physio_run_all_tests()
+%
+% The required example data and test reference results are downloaded to
+% the canonical PhysIO folders when they are not already available. Both
+% suites are run recursively. An error is raised after both suites finish
+% if any test failed or was incomplete, making this function suitable as a
+% single pre-pull-request entry point for developers and coding agents.
+%
+% OUT
+%   testResults    Struct with fields unit and integration containing the
+%                  corresponding matlab.unittest.TestResult arrays.
+%
+% See also tapas_physio_run_unit_tests,
+%          tapas_physio_run_integration_tests,
+%          tapas_physio_get_paths_for_tests
+
+% Verify the external test data before starting either suite. The helper
+% downloads the version-matched Zenodo archives when required.
+doUseZenodoPaths = true;
+doVerifyPath = true;
+doDownloadData = true;
+[pathExamples, pathTestReferenceResults] = tapas_physio_get_paths_for_tests( ...
+    doUseZenodoPaths, doVerifyPath, doDownloadData);
+
+fprintf('PhysIO example data: %s\n', pathExamples);
+fprintf('PhysIO test reference results: %s\n\n', pathTestReferenceResults);
+
+fprintf('===== PhysIO unit tests =====\n');
+testResults.unit = tapas_physio_run_unit_tests();
+
+fprintf('\n===== PhysIO integration tests =====\n');
+testResults.integration = tapas_physio_run_integration_tests();
+
+fprintf('\n===== PhysIO test summary =====\n');
+print_summary('Unit', testResults.unit);
+print_summary('Integration', testResults.integration);
+
+allResults = [testResults.unit, testResults.integration];
+if isempty(allResults)
+    error('tapas:physio:tests:NoTests', ...
+        'No PhysIO unit or integration tests were discovered.');
+end
+
+if any([allResults.Failed]) || any([allResults.Incomplete])
+    error('tapas:physio:tests:Failed', ...
+        'PhysIO tests did not complete successfully. See the test summary above.');
+end
+end
+
+
+function print_summary(label, results)
+% Print compact totals for one test suite.
+
+fprintf('%s: %d total, %d passed, %d failed, %d incomplete\n', ...
+    label, numel(results), nnz([results.Passed]), ...
+    nnz([results.Failed]), nnz([results.Incomplete]));
+end

--- a/tests/tapas_physio_run_all_tests.m
+++ b/tests/tapas_physio_run_all_tests.m
@@ -3,11 +3,13 @@ function testResults = tapas_physio_run_all_tests()
 %
 %   testResults = tapas_physio_run_all_tests()
 %
-% The required example data and test reference results are downloaded to
-% the canonical PhysIO folders when they are not already available. Both
-% suites are run recursively. An error is raised after both suites finish
-% if any test failed or was incomplete, making this function suitable as a
-% single pre-pull-request entry point for developers and coding agents.
+% Run tapas_physio_init() before calling this function so that PhysIO and
+% SPM are initialized on the MATLAB path. If necessary, this function
+% downloads both the PhysIO example data and the test reference results to
+% their canonical PhysIO folders. Both suites are run recursively. An error
+% is raised after both suites finish if any test failed or was incomplete,
+% making this function suitable as a single pre-pull-request entry point
+% for developers and coding agents.
 %
 % OUT
 %   testResults    Struct with fields unit and integration containing the
@@ -17,8 +19,9 @@ function testResults = tapas_physio_run_all_tests()
 %          tapas_physio_run_integration_tests,
 %          tapas_physio_get_paths_for_tests
 
-% Verify the external test data before starting either suite. The helper
-% downloads the version-matched Zenodo archives when required.
+% Verify both external datasets before starting either suite. If the
+% example data or test reference results are missing, the helper downloads
+% their version-matched Zenodo archives.
 doUseZenodoPaths = true;
 doVerifyPath = true;
 doDownloadData = true;


### PR DESCRIPTION
## Summary

This PR adds `tapas_physio_run_all_tests()` as a single entry point for running the complete PhysIO test suite.

The new runner:

- discovers unit and integration tests recursively;
- verifies that the PhysIO example data and test reference results are available;
- downloads the version-matched datasets from Zenodo when necessary;
- runs both test suites;
- prints a concise summary; and
- raises an error if no tests are discovered or any test fails or remains incomplete.

## Motivation

The previously documented use of `runtests('.')` does not recurse into the unit-test category subfolders. It can therefore miss tests or even report that no tests were found.

A single reliable command is particularly useful for developers and coding agents performing pre-pull-request validation:

    tapas_physio_init();
    testResults = tapas_physio_run_all_tests();

PhysIO and SPM should be initialized before running the suite.

## Additional changes

- Correct the example-data download command in `README.md` to `tapas_physio_download_example_data()`.
- Correct `tapas_physio_get_path_examples()` so that it downloads example data—not test reference results—when examples are missing.
- Recursively verify that downloaded example data can be found after the download completes.
- Update `AGENTS.md` to document the complete test workflow and require successful unit and integration tests before a pull request is marked ready.

## Validation

The combined runner was exercised with both suites:

- 14/14 unit tests passed
- 41/41 integration tests passed

MATLAB Code Analyzer reported no issues in the new runner.

## Development history

This change was originally developed and reviewed in [mrikasper/PhysIO#9](https://github.com/mrikasper/PhysIO/pull/9). This description is self-contained; the linked fork PR is retained as supplementary development history.