### PR TITLE
Modernize multipage figure export with PDF support

### DIFF
--- a/code/plot/tapas_physio_print_figs_to_file.m
+++ b/code/plot/tapas_physio_print_figs_to_file.m
@@ -40,15 +40,31 @@ else
     [pfx, fn, sfx] = fileparts(verbose.fig_output_file);
     switch sfx
         case '.ps'
-            warning('tapas:physio:PostScriptNotSupported', ...
-                ['PostScript export is no longer supported by MATLAB. ' ...
-                'Saving the report as PDF instead.']);
-            verbose.fig_output_file = fullfile(pfx, [fn '.pdf']);
-            export_figures_to_pdf(verbose.fig_handles, ...
-                verbose.fig_output_file);
+            % exportgraphics was introduced in MATLAB R2020a (version 9.8).
+            if ~verLessThan('matlab', '9.8')
+                warning('tapas:physio:PostScriptNotSupported', ...
+                    ['PostScript export is no longer supported by this ' ...
+                    'MATLAB release. Saving the report as PDF instead.']);
+                verbose.fig_output_file = fullfile(pfx, [fn '.pdf']);
+                export_figures_to_pdf(verbose.fig_handles, ...
+                    verbose.fig_output_file);
+            else
+                export_figures_to_postscript(verbose.fig_handles, ...
+                    verbose.fig_output_file);
+            end
         case '.pdf'
-            export_figures_to_pdf(verbose.fig_handles, ...
-                verbose.fig_output_file);
+            % exportgraphics was introduced in MATLAB R2020a (version 9.8).
+            if ~verLessThan('matlab', '9.8')
+                export_figures_to_pdf(verbose.fig_handles, ...
+                    verbose.fig_output_file);
+            else
+                warning('tapas:physio:PdfNotSupported', ...
+                    ['Multipage PDF export requires MATLAB R2020a or ' ...
+                    'newer. Saving the report as PostScript instead.']);
+                verbose.fig_output_file = fullfile(pfx, [fn '.ps']);
+                export_figures_to_postscript(verbose.fig_handles, ...
+                    verbose.fig_output_file);
+            end
         case '.fig'
             for k=1:numel(verbose.fig_handles)
                 saveas(verbose.fig_handles(k), fullfile(pfx,[fn sprintf('_%02d', k) sfx]));
@@ -76,5 +92,20 @@ end
 function export_figures_to_pdf(figHandles, fileName)
 for k = 1:numel(figHandles)
     exportgraphics(figHandles(k), fileName, 'Append', k > 1);
+end
+end
+
+function export_figures_to_postscript(figHandles, fileName)
+try % Level 2 PostScript
+    for k = 1:numel(figHandles)
+        print(figHandles(k), '-dpsc2', '-append', fileName); %#ok<PRINTPS4>
+    end
+catch
+    if isfile(fileName)
+        delete(fileName);
+    end
+    for k = 1:numel(figHandles)
+        print(figHandles(k), '-dpsc', '-append', fileName); %#ok<PRINTPS2>
+    end
 end
 end

--- a/code/plot/tapas_physio_print_figs_to_file.m
+++ b/code/plot/tapas_physio_print_figs_to_file.m
@@ -37,21 +37,20 @@ if ~isfield(verbose, 'fig_handles') || numel(verbose.fig_handles) == 0 || ...
         tapas_physio_log('No figures found to save to file', verbose, 1);
     end
 else
-    [pfx fn sfx] = fileparts(verbose.fig_output_file);
+    [pfx, fn, sfx] = fileparts(verbose.fig_output_file);
     switch sfx
         case '.ps'
-            try %level 2 PS
-                for k=1:length(verbose.fig_handles)
-                    print(verbose.fig_handles(k),'-dpsc2', '-append',verbose.fig_output_file);
-                end
-            catch
-                delete(verbose.fig_output_file);
-                for k=1:length(verbose.fig_handles)
-                    print(verbose.fig_handles(k), '-dpsc', '-append', verbose.fig_output_file);
-                end
-             end
+            warning('tapas:physio:PostScriptNotSupported', ...
+                ['PostScript export is no longer supported by MATLAB. ' ...
+                'Saving the report as PDF instead.']);
+            verbose.fig_output_file = fullfile(pfx, [fn '.pdf']);
+            export_figures_to_pdf(verbose.fig_handles, ...
+                verbose.fig_output_file);
+        case '.pdf'
+            export_figures_to_pdf(verbose.fig_handles, ...
+                verbose.fig_output_file);
         case '.fig'
-            for k=1:length(verbose.fig_handles)
+            for k=1:numel(verbose.fig_handles)
                 saveas(verbose.fig_handles(k), fullfile(pfx,[fn sprintf('_%02d', k) sfx]));
             end
         case '' % empty, do nothing!
@@ -67,8 +66,15 @@ else
                     printFormat = '-djpeg';
                     warning('Image format to save output figures not supported, choosing jpeg instead');
             end
-            for k=1:length(verbose.fig_handles)
+            for k=1:numel(verbose.fig_handles)
                 print(verbose.fig_handles(k),printFormat,fullfile(pfx,[fn sprintf('_%02d', k) sfx]));
             end
     end
+end
+end
+
+function export_figures_to_pdf(figHandles, fileName)
+for k = 1:numel(figHandles)
+    exportgraphics(figHandles(k), fileName, 'Append', k > 1);
+end
 end

--- a/tests/unit/plot/tapas_physio_print_figs_to_file_test.m
+++ b/tests/unit/plot/tapas_physio_print_figs_to_file_test.m
@@ -1,0 +1,64 @@
+function tests = tapas_physio_print_figs_to_file_test()
+% Tests figure-report export formats.
+
+tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+testFolder = fileparts(mfilename('fullpath'));
+repoRoot = fileparts(fileparts(fileparts(testFolder)));
+testCase.TestData.pathFixture = ...
+    matlab.unittest.fixtures.PathFixture( ...
+    fullfile(repoRoot, 'code'), IncludingSubfolders=true);
+testCase.applyFixture(testCase.TestData.pathFixture);
+end
+
+function test_exports_multipage_pdf(testCase)
+[verbose, testFolder] = create_test_figures(testCase, 'report.pdf');
+
+verbose = tapas_physio_print_figs_to_file(verbose, testFolder);
+
+verifyEqual(testCase, verbose.fig_output_file, ...
+    fullfile(testFolder, 'report.pdf'));
+verify_report_exists(testCase, verbose.fig_output_file);
+end
+
+function test_converts_legacy_postscript_to_pdf(testCase)
+[verbose, testFolder] = create_test_figures(testCase, 'report.ps');
+
+verifyWarning(testCase, ...
+    @() tapas_physio_print_figs_to_file(verbose, testFolder), ...
+    'tapas:physio:PostScriptNotSupported');
+verbose = tapas_physio_print_figs_to_file_suppress_warning( ...
+    verbose, testFolder);
+
+verifyEqual(testCase, verbose.fig_output_file, ...
+    fullfile(testFolder, 'report.pdf'));
+verify_report_exists(testCase, verbose.fig_output_file);
+end
+
+function [verbose, testFolder] = create_test_figures(testCase, fileName)
+testFolder = tempname;
+mkdir(testFolder);
+testCase.addTeardown(@() rmdir(testFolder, 's'));
+figures = [figure('Visible', 'off'), figure('Visible', 'off')];
+testCase.addTeardown(@() close(figures));
+plot(axes('Parent', figures(1)), 1:3);
+plot(axes('Parent', figures(2)), 3:-1:1);
+verbose.level = 0;
+verbose.fig_handles = figures;
+verbose.fig_output_file = fileName;
+end
+
+function verbose = tapas_physio_print_figs_to_file_suppress_warning( ...
+        verbose, testFolder)
+warningState = warning('off', 'tapas:physio:PostScriptNotSupported');
+cleanup = onCleanup(@() warning(warningState));
+verbose = tapas_physio_print_figs_to_file(verbose, testFolder);
+end
+
+function verify_report_exists(testCase, fileName)
+fileInfo = dir(fileName);
+verifyTrue(testCase, isfile(fileName));
+verifyGreaterThan(testCase, fileInfo.bytes, 0);
+end


### PR DESCRIPTION
## Summary

This PR modernizes PhysIO’s multipage figure export while preserving compatibility with older MATLAB releases.

On MATLAB R2020a and newer, the implementation:

- exports reports directly as multipage PDF files using `exportgraphics`;
- converts legacy `.ps` output requests to `.pdf`; and
- emits a targeted warning when a requested PostScript filename is changed to PDF.

On MATLAB releases older than R2020a, where `exportgraphics` is unavailable, the existing PostScript export is retained. A direct `.pdf` request falls back to PostScript with a warning.

## Motivation

Recent MATLAB releases no longer support the full-page PostScript devices used by the previous implementation. Both the original `-dpsc2` call and its `-dpsc` fallback fail.

The suggested `-deps` replacement produces encapsulated PostScript, which is not suitable for appending multiple report pages. Native multipage PDF export is therefore the appropriate replacement on supported MATLAB versions.

## Compatibility

`exportgraphics` was introduced in MATLAB R2020a (version 9.8). The implementation checks the MATLAB version directly with `verLessThan`:

- MATLAB R2020a or newer: use native multipage PDF export.
- Older MATLAB releases: retain the original PostScript conversion path.

## Tests

PhysIO-style function-based tests cover:

- direct multipage PDF export; and
- conversion of a legacy `.ps` request to PDF.

Validation results:

- 2 tests passed
- 0 tests failed
- MATLAB Code Analyzer reported no findings in either changed file

## Development history

This change was originally developed and reviewed in [mrikasper/PhysIO#4](https://github.com/mrikasper/PhysIO/pull/4). This description is self-contained; the linked fork PR is retained as supplementary development history.