### PR TITLE
Fix missing tSNR reference-map recursion

### DIFF
--- a/code/assess/tapas_physio_compute_tsnr_spm.m
+++ b/code/assess/tapas_physio_compute_tsnr_spm.m
@@ -182,12 +182,12 @@ if doComputeRatio
     fileTsnrCompare = fullfile(oldDirSpm, sprintf('tSNR_con%04d.nii', iCForRatio));
     
     % Load or compute tSNR image for comparison contrast
-    if ~exist(fileTsnrCompare, 'file');
+    if ~exist(fileTsnrCompare, 'file')
         % when computed, don't compute another ratio, and don't delete tmp
         % here! (will be done at the end)
         tSnrCompareImage = tapas_physio_compute_tsnr_spm(...
             fullfile(oldDirSpm, 'SPM.mat'), ...
-            iCForRatio, doInvert, [], 1);
+            iCForRatio, [], doInvert, 1);
     else
         VCompare = spm_vol(fileTsnrCompare);
         tSnrCompareImage = spm_read_vols(VCompare);


### PR DESCRIPTION
## Summary

This PR fixes the recursive tSNR calculation used when the reference image for a ratio calculation does not yet exist.

The recursive call now:

- passes an empty `iCForRatio`, disabling another ratio calculation;
- preserves the caller’s `doInvert` setting in the correct argument position; and
- continues to preserve temporary files for cleanup by the outer call.

## Root cause

`tapas_physio_compute_tsnr_spm` accepts the relevant arguments in this order:

    iC, iCForRatio, doInvert, doSaveNewContrasts

The recursive call previously passed:

    iCForRatio, doInvert, [], 1

Consequently, `doInvert` was interpreted as `iCForRatio`, while the recursive call received an empty `doInvert` value. This could trigger an unintended nested ratio calculation and made the result depend on whether the reference tSNR image already existed.

The corrected call is:

    iCForRatio, [], doInvert, 1

## Scope

The change is limited to the recursive argument order in `tapas_physio_compute_tsnr_spm`, plus removal of an unnecessary semicolon after the associated `if` condition.

No dedicated unit test is included because the defect is a direct argument-order mistake in an SPM-dependent recursive call; testing it in isolation would require substantial mocking unrelated to the fix.

## Development history

This change was originally developed and reviewed in [mrikasper/PhysIO#5](https://github.com/mrikasper/PhysIO/pull/5). This description is self-contained; the linked fork PR is retained as supplementary development history.