### PR TITLE
Support BIDS physiology files without a trigger column

### DIFF
--- a/code/readin/tapas_physio_read_physlogfiles_bids.m
+++ b/code/readin/tapas_physio_read_physlogfiles_bids.m
@@ -401,11 +401,15 @@ end
 % 1 = cardiac, 2 = resp, 3 = trigger
 bidsColumnNames = {'cardiac', 'respiratory', 'trigger'};
 idxCol = 1:3;  %set default values for columns from BIDS
+hasTriggerColumn = ~hasJsonFile;
 for iCol = 1:3
     if hasJsonFile
         idxCurrCol = find(cellfun(@(x) isequal(lower(x), bidsColumnNames{iCol}), val.Columns));
         if ~isempty(idxCurrCol)
             idxCol(iCol) = idxCurrCol;
+            if strcmpi(bidsColumnNames{iCol}, 'trigger')
+                hasTriggerColumn = true;
+            end
         end
     end
 end
@@ -413,7 +417,6 @@ end
 C = tapas_physio_read_columnar_textfiles(fileName, 'BIDS', nColumns);
 c = double(C{idxCol(1)});
 r = double(C{idxCol(2)});
-trigger_trace = double(C{idxCol(3)}); % trigger has 1, rest is 0;
 
 
 %% Create timing vector from samples
@@ -422,8 +425,13 @@ nSamples = max(numel(c), numel(r));
 t = -tRelStartScan + ((0:(nSamples-1))*dt)';
 
 %% Recompute acq_codes as for Siemens (volume on/volume off)
-[acq_codes, verbose] = tapas_physio_create_acq_codes_from_trigger_trace(t, trigger_trace, verbose, ...
-        1, 'rising', 'auto_matched');
+if hasTriggerColumn
+    trigger_trace = double(C{idxCol(3)}); % trigger has 1, rest is 0;
+    [acq_codes, verbose] = tapas_physio_create_acq_codes_from_trigger_trace(t, trigger_trace, verbose, ...
+            1, 'rising', 'auto_matched');
+else
+    acq_codes = [];
+end
 
 %% Plot extracted traces so far
 if DEBUG

--- a/code/readin/tapas_physio_read_physlogfiles_bids.m
+++ b/code/readin/tapas_physio_read_physlogfiles_bids.m
@@ -356,7 +356,6 @@ end
 
 hasJsonFile = isfile(fileJson);
 
-nColumns = [];
 if hasJsonFile
     val = jsondecode(fileread(fileJson));
     nColumns = numel(val.Columns);
@@ -364,6 +363,7 @@ else
     verbose = tapas_physio_log(...
         ['No .json file found. Please specify log_files.sampling_interval' ...
         ' and log_files.relative_start_acquisition explicitly.'], verbose, 1);
+    nColumns = tapas_physio_count_bids_columns(fileName);
 end
 
 dt = log_files.sampling_interval;
@@ -401,7 +401,7 @@ end
 % 1 = cardiac, 2 = resp, 3 = trigger
 bidsColumnNames = {'cardiac', 'respiratory', 'trigger'};
 idxCol = 1:3;  %set default values for columns from BIDS
-hasTriggerColumn = ~hasJsonFile;
+hasTriggerColumn = false;
 for iCol = 1:3
     if hasJsonFile
         idxCurrCol = find(cellfun(@(x) isequal(lower(x), bidsColumnNames{iCol}), val.Columns));
@@ -415,6 +415,9 @@ for iCol = 1:3
 end
 
 C = tapas_physio_read_columnar_textfiles(fileName, 'BIDS', nColumns);
+if ~hasJsonFile
+    hasTriggerColumn = nColumns >= idxCol(3);
+end
 c = double(C{idxCol(1)});
 r = double(C{idxCol(2)});
 
@@ -475,5 +478,15 @@ legend({
     sprintf('original %s time series', stringOrigInterp{2}) });
 title(stringTitle);
 xlabel('time (seconds');
+end
+
+function nColumns = tapas_physio_count_bids_columns(fileName)
+% Determine the positional column count for legacy files without JSON.
+
+fid = fopen(fileName, 'r');
+cleanupFile = onCleanup(@() fclose(fid));
+firstLine = strtrim(fgetl(fid));
+nColumns = numel(regexp(firstLine, '\s+', 'split'));
+
 end
 

--- a/tests/unit/readin/tapas_physio_readin_bids_missing_trigger_test.m
+++ b/tests/unit/readin/tapas_physio_readin_bids_missing_trigger_test.m
@@ -3,19 +3,55 @@ classdef tapas_physio_readin_bids_missing_trigger_test < matlab.unittest.TestCas
 
     methods (Test)
         function test_unified_file_without_trigger(testCase)
+            [logFiles, verbose] = testCase.createBidsFixture( ...
+                '1\t2\n3\t4\n5\t6\n', ...
+                {'cardiac', 'respiratory'});
+
+            [c, r, t, cpulse, acq_codes] = ...
+                tapas_physio_read_physlogfiles_bids(logFiles, ...
+                'PPU', verbose);
+
+            testCase.verifyEqual(c, [1; 3; 5]);
+            testCase.verifyEqual(r, [2; 4; 6]);
+            testCase.verifyEqual(t, [0; 0.001; 0.002], 'AbsTol', eps);
+            testCase.verifyEmpty(cpulse);
+            testCase.verifyEmpty(acq_codes);
+        end
+
+        function test_unified_file_with_trigger(testCase)
+            [logFiles, verbose] = testCase.createBidsFixture( ...
+                '1\t2\t1\n3\t4\t0\n5\t6\t1\n', ...
+                {'cardiac', 'respiratory', 'trigger'});
+
+            [c, r, t, cpulse, acq_codes] = ...
+                tapas_physio_read_physlogfiles_bids(logFiles, ...
+                'PPU', verbose);
+
+            testCase.verifyEqual(c, [1; 3; 5]);
+            testCase.verifyEqual(r, [2; 4; 6]);
+            testCase.verifyEqual(t, [0; 0.001; 0.002], 'AbsTol', eps);
+            testCase.verifyEmpty(cpulse);
+            testCase.verifyEqual(acq_codes, [8; 0; 8]);
+        end
+    end
+
+    methods (Access = private)
+        function [logFiles, verbose] = createBidsFixture( ...
+                testCase, tsvContents, columns)
             pathTestData = tempname;
             mkdir(pathTestData);
             testCase.addTeardown(@() rmdir(pathTestData, 's'));
 
             fileTsv = fullfile(pathTestData, 'minimal_physio.tsv');
             fid = fopen(fileTsv, 'w');
-            fprintf(fid, '1\t2\n3\t4\n5\t6\n');
+            fprintf(fid, tsvContents);
             fclose(fid);
 
             fileJson = fullfile(pathTestData, 'minimal_physio.json');
+            metadata = struct('SamplingFrequency', 1000, ...
+                'StartTime', 0, 'Columns', {columns});
             fid = fopen(fileJson, 'w');
-            fprintf(fid, ['{"SamplingFrequency":1000,"StartTime":0,' ...
-                '"Columns":["cardiac","respiratory"]}']);
+            fprintf(fid, '%s', jsonencode(metadata));
             fclose(fid);
 
             physio = tapas_physio_new();
@@ -26,15 +62,8 @@ classdef tapas_physio_readin_bids_missing_trigger_test < matlab.unittest.TestCas
             physio.log_files.relative_start_acquisition = [];
             physio.verbose.level = 0;
 
-            [c, r, t, cpulse, acq_codes] = ...
-                tapas_physio_read_physlogfiles_bids(physio.log_files, ...
-                'PPU', physio.verbose);
-
-            testCase.verifyEqual(c, [1; 3; 5]);
-            testCase.verifyEqual(r, [2; 4; 6]);
-            testCase.verifyEqual(t, [0; 0.001; 0.002], 'AbsTol', eps);
-            testCase.verifyEmpty(cpulse);
-            testCase.verifyEmpty(acq_codes);
+            logFiles = physio.log_files;
+            verbose = physio.verbose;
         end
     end
 end

--- a/tests/unit/readin/tapas_physio_readin_bids_missing_trigger_test.m
+++ b/tests/unit/readin/tapas_physio_readin_bids_missing_trigger_test.m
@@ -1,0 +1,40 @@
+classdef tapas_physio_readin_bids_missing_trigger_test < matlab.unittest.TestCase
+    % Regression tests for BIDS recordings without an optional trigger column.
+
+    methods (Test)
+        function test_unified_file_without_trigger(testCase)
+            pathTestData = tempname;
+            mkdir(pathTestData);
+            testCase.addTeardown(@() rmdir(pathTestData, 's'));
+
+            fileTsv = fullfile(pathTestData, 'minimal_physio.tsv');
+            fid = fopen(fileTsv, 'w');
+            fprintf(fid, '1\t2\n3\t4\n5\t6\n');
+            fclose(fid);
+
+            fileJson = fullfile(pathTestData, 'minimal_physio.json');
+            fid = fopen(fileJson, 'w');
+            fprintf(fid, ['{"SamplingFrequency":1000,"StartTime":0,' ...
+                '"Columns":["cardiac","respiratory"]}']);
+            fclose(fid);
+
+            physio = tapas_physio_new();
+            physio.log_files.cardiac = fileTsv;
+            physio.log_files.respiration = fileTsv;
+            physio.log_files.scan_timing = fileJson;
+            physio.log_files.sampling_interval = [];
+            physio.log_files.relative_start_acquisition = [];
+            physio.verbose.level = 0;
+
+            [c, r, t, cpulse, acq_codes] = ...
+                tapas_physio_read_physlogfiles_bids(physio.log_files, ...
+                'PPU', physio.verbose);
+
+            testCase.verifyEqual(c, [1; 3; 5]);
+            testCase.verifyEqual(r, [2; 4; 6]);
+            testCase.verifyEqual(t, [0; 0.001; 0.002], 'AbsTol', eps);
+            testCase.verifyEmpty(cpulse);
+            testCase.verifyEmpty(acq_codes);
+        end
+    end
+end

--- a/tests/unit/readin/tapas_physio_readin_bids_missing_trigger_test.m
+++ b/tests/unit/readin/tapas_physio_readin_bids_missing_trigger_test.m
@@ -33,6 +33,36 @@ classdef tapas_physio_readin_bids_missing_trigger_test < matlab.unittest.TestCas
             testCase.verifyEmpty(cpulse);
             testCase.verifyEqual(acq_codes, [8; 0; 8]);
         end
+
+        function test_unified_file_without_json_or_trigger(testCase)
+            [logFiles, verbose] = testCase.createLegacyFixture( ...
+                '1\t2\n3\t4\n5\t6\n');
+
+            [c, r, t, cpulse, acq_codes] = ...
+                tapas_physio_read_physlogfiles_bids(logFiles, ...
+                'PPU', verbose);
+
+            testCase.verifyEqual(c, [1; 3; 5]);
+            testCase.verifyEqual(r, [2; 4; 6]);
+            testCase.verifyEqual(t, [0; 0.001; 0.002], 'AbsTol', eps);
+            testCase.verifyEmpty(cpulse);
+            testCase.verifyEmpty(acq_codes);
+        end
+
+        function test_unified_file_without_json_with_trigger(testCase)
+            [logFiles, verbose] = testCase.createLegacyFixture( ...
+                '1\t2\t1\n3\t4\t0\n5\t6\t1\n');
+
+            [c, r, t, cpulse, acq_codes] = ...
+                tapas_physio_read_physlogfiles_bids(logFiles, ...
+                'PPU', verbose);
+
+            testCase.verifyEqual(c, [1; 3; 5]);
+            testCase.verifyEqual(r, [2; 4; 6]);
+            testCase.verifyEqual(t, [0; 0.001; 0.002], 'AbsTol', eps);
+            testCase.verifyEmpty(cpulse);
+            testCase.verifyEqual(acq_codes, [8; 0; 8]);
+        end
     end
 
     methods (Access = private)
@@ -60,6 +90,29 @@ classdef tapas_physio_readin_bids_missing_trigger_test < matlab.unittest.TestCas
             physio.log_files.scan_timing = fileJson;
             physio.log_files.sampling_interval = [];
             physio.log_files.relative_start_acquisition = [];
+            physio.verbose.level = 0;
+
+            logFiles = physio.log_files;
+            verbose = physio.verbose;
+        end
+
+        function [logFiles, verbose] = createLegacyFixture( ...
+                testCase, tsvContents)
+            pathTestData = tempname;
+            mkdir(pathTestData);
+            testCase.addTeardown(@() rmdir(pathTestData, 's'));
+
+            fileTsv = fullfile(pathTestData, 'minimal_physio.tsv');
+            fid = fopen(fileTsv, 'w');
+            fprintf(fid, tsvContents);
+            fclose(fid);
+
+            physio = tapas_physio_new();
+            physio.log_files.cardiac = fileTsv;
+            physio.log_files.respiration = fileTsv;
+            physio.log_files.scan_timing = '';
+            physio.log_files.sampling_interval = 0.001;
+            physio.log_files.relative_start_acquisition = 0;
             physio.verbose.level = 0;
 
             logFiles = physio.log_files;


### PR DESCRIPTION
## Summary

This PR allows the unified BIDS physiology reader to load recordings when the optional `trigger` column is absent.

It preserves the existing behavior for files that include a trigger column and supports both:

- BIDS files with a JSON sidecar defining the columns; and
- legacy files without a JSON sidecar, using positional columns.

## Background

A BIDS physiological recording is not required to contain a `trigger` column. The existing reader nevertheless assumed that a third column was always present and indexed it unconditionally:

    trigger_trace = double(C{idxCol(3)});

Valid two-column recordings containing only `cardiac` and `respiratory` data therefore failed with an indexing error before the downstream nominal-timing fallback could be used.

## Implementation

For files with a JSON sidecar, the reader now records whether `trigger` is present in the `Columns` metadata.

For legacy files without JSON metadata, the reader counts the columns in the first data row and treats the third positional column as a trigger only when it exists.

When a trigger column is present, acquisition codes are calculated exactly as before. When it is absent, `acq_codes` is returned empty so the existing downstream timing fallback can be used.

## Tests

Focused regression tests cover four layouts:

- JSON sidecar without a trigger column;
- JSON sidecar with a trigger column;
- legacy file without JSON or a trigger column; and
- legacy file without JSON but with a trigger column.

The tests verify the cardiac and respiratory signals, timing vector, and expected acquisition-code behavior.

The complete PhysIO unit and integration test suites were also run successfully during review of the fork PR.

## Development history

This change was originally developed and reviewed in [mrikasper/PhysIO#2](https://github.com/mrikasper/PhysIO/pull/2). This description is self-contained; the linked fork PR is retained as supplementary development history.