### PR TITLE
Default contrast reports to PDF

### DIFF
--- a/code/assess/tapas_physio_overlay_contrasts.m
+++ b/code/assess/tapas_physio_overlay_contrasts.m
@@ -3,12 +3,12 @@ function varargout = tapas_physio_overlay_contrasts(varargin)
 % instead of showing results table
 %
 %  - Section plots on an anatomical overlay are created and saved as
-%    post-script file with one page for each contrast
+%    PDF file with one page for each contrast
 %
 %  - Input parameters are specified via name/value pairs, e.g.
 %
 %   fileReport = tapas_physio_overlay_contrasts(...
-%                   'fileReport', 'contrast_report.ps', ...
+%                   'fileReport', 'contrast_report.pdf', ...
 %                   'fileSpm', 'analysisFolder/SPM.mat', ...
 %                   'fileStructural', 'anatomyFolder/warpedAnatomy.nii')
 %
@@ -16,7 +16,8 @@ function varargout = tapas_physio_overlay_contrasts(varargin)
 %
 %   Required parameters:
 %
-%                  fileReport: post-script file to print results to
+%                  fileReport: file to print results to; the extension sets
+%                              the format (default: PDF)
 %              fileStructural: structural underlay for results,
 %                              e.g. 'mean.nii'
 %                               default: spm/canonical/avg152T1.nii
@@ -74,7 +75,7 @@ function varargout = tapas_physio_overlay_contrasts(varargin)
 % general paths study
 defaults.titleGraphicsWindow    = '';
 % PhysIO Toolbox code should be in same folder as this file
-defaults.fileReport             = 'report_contrasts.ps'; % where contrast maps are saved
+defaults.fileReport             = 'report_contrasts.pdf'; % where contrast maps are saved
 defaults.fileStructural         = 'mean.nii';
 defaults.fileSpm                = 'SPM.mat';
 defaults.drawCrosshair          = true;
@@ -139,16 +140,18 @@ for idxContrast = idxContrasts
         
         % Change directory, ince spm_print always prepend current directory 
         % to print-file name :-(
-        [pathReport, filenameReport] = fileparts(fileReport);
+        [pathReport, filenameReport, extensionReport] = fileparts(fileReport);
         if isempty(pathReport)
             pathReport = pwd;
         end
         pathTmp = pwd;
         
         cd(pathReport);
+
+        filenameReport = [filenameReport extensionReport];
         
         if saveTable
-            spm_print(fileReport)
+            tapas_physio_print_report(filenameReport);
         end
         
         xSPM = evalin('base', 'xSPM');
@@ -181,7 +184,7 @@ for idxContrast = idxContrasts
             spm_orthviews('SetBlobsMax', 1, 1, colorbarMax)
         end
        
-        spm_print(filenameReport);
+        tapas_physio_print_report(filenameReport);
         cd(pathTmp);
 end
 cd(pathBeforeReport);

--- a/code/assess/tapas_physio_print_report.m
+++ b/code/assess/tapas_physio_print_report.m
@@ -17,7 +17,8 @@ if strcmpi(extensionReport, '.pdf') && verLessThan('matlab', '9.8') == 0
         error('tapas_physio:GraphicsFigureNotFound', ...
             'The SPM Graphics figure could not be found.');
     end
-    exportgraphics(graphicsFigure, fileReport, 'Append', isfile(fileReport));
+    fileReport = tapas_physio_export_figures( ...
+        graphicsFigure, fileReport, isfile(fileReport));
     return;
 end
 

--- a/code/assess/tapas_physio_print_report.m
+++ b/code/assess/tapas_physio_print_report.m
@@ -1,0 +1,31 @@
+function fileReport = tapas_physio_print_report(fileReport)
+% Print the SPM Graphics window to an extension-aware report file.
+%
+% If fileReport has no extension, PDF is used. PDF pages are appended with
+% exportgraphics on MATLAB R2020a and newer. Other extensions supported by
+% spm_print, including explicit PostScript requests, use SPM's exporter.
+
+[pathReport, nameReport, extensionReport] = fileparts(fileReport);
+if isempty(extensionReport)
+    extensionReport = '.pdf';
+end
+fileReport = fullfile(pathReport, [nameReport extensionReport]);
+
+if strcmpi(extensionReport, '.pdf') && verLessThan('matlab', '9.8') == 0
+    graphicsFigure = spm_figure('FindWin', 'Graphics');
+    if isempty(graphicsFigure)
+        error('tapas_physio:GraphicsFigureNotFound', ...
+            'The SPM Graphics figure could not be found.');
+    end
+    exportgraphics(graphicsFigure, fileReport, 'Append', isfile(fileReport));
+    return;
+end
+
+printFormat = extensionReport(2:end);
+printOptions = spm_print('format', printFormat);
+if isempty(printOptions)
+    error('tapas_physio:UnsupportedPrintFormat', ...
+        'Unsupported report file extension: %s', extensionReport);
+end
+spm_print(fileReport, 'Graphics', printOptions);
+end

--- a/code/assess/tapas_physio_report_contrasts.m
+++ b/code/assess/tapas_physio_report_contrasts.m
@@ -3,13 +3,13 @@ function varargout = tapas_physio_report_contrasts(varargin)
 % in a given GLM
 %
 %  - Section plots on an anatomical overlay are created and saved as
-%    post-script file with one page for each contrasts
+%    PDF file with one page for each contrast
 %
 %  - Input parameters are specified via name/value pairs, e.g.
 %
 %
 %   args = tapas_physio_report_contrasts(...
-%                   'fileReport', 'physio.ps', ...
+%                   'fileReport', 'physio.pdf', ...
 %                   'fileSpm', 'analysisFolder/SPM.mat', ...
 %                   'filePhysIO', 'analysisFolder/physio.mat', ...
 %                   'fileStructural', 'anatomyFolder/warpedAnatomy.nii')
@@ -18,12 +18,13 @@ function varargout = tapas_physio_report_contrasts(varargin)
 %
 %   Required parameters:
 %
-%                  fileReport: sets the path and file name for the postscript 
-%                              file your contrast report is printed to. 
+%                  fileReport: sets the path and file name for the file your
+%                              contrast report is printed to. Its extension
+%                              selects the format.
 %                              A reasonable (and default) location is the 
 %                              single subject analysis folder so the file 
 %                              resides with the GLM (fileSPM)
-%                              default: 'pathSpm/physio_report_contrasts.ps';
+%                              default: 'pathSpm/physio_report_contrasts.pdf';
 %              fileStructural: structural underlay for results,
 %                              e.g. 'mean.nii'
 %                     fileSpm: SPM.mat holding physiological regressors,
@@ -59,7 +60,7 @@ function varargout = tapas_physio_report_contrasts(varargin)
 %                              in each plot
 %       saveTable              true of false (default)
 %                              prints screenshot of results table to
-%                              ps-file as well
+%                              report file as well
 %
 % OUT
 %   args    structure of default and updated arguments used in this
@@ -88,7 +89,7 @@ function varargout = tapas_physio_report_contrasts(varargin)
 defaults.titleGraphicsWindow = '';
 % PhysIO Toolbox code should be in same folder as this file
 defaults.filePhysIO      = 'physio.mat';
-defaults.fileReport      = 'physio_report_contrasts.ps'; % where contrast maps are saved
+defaults.fileReport      = 'physio_report_contrasts.pdf'; % where contrast maps are saved
 defaults.fileStructural  = 'mean.nii';
 defaults.fileSpm         = 'SPM.mat';
 defaults.drawCrosshair   = true;

--- a/code/plot/tapas_physio_export_figures.m
+++ b/code/plot/tapas_physio_export_figures.m
@@ -1,0 +1,68 @@
+function fileName = tapas_physio_export_figures( ...
+        figHandles, fileName, appendToExisting)
+% Export figure handles to a multipage PDF or legacy PostScript file.
+%
+%   fileName = tapas_physio_export_figures( ...
+%       figHandles, fileName, appendToExisting)
+%
+% PDF export uses exportgraphics on MATLAB R2020a and newer. On those
+% releases, a requested PostScript file is converted to PDF. Older MATLAB
+% releases use PostScript because multipage PDF export is unavailable.
+
+if nargin < 3
+    appendToExisting = false;
+end
+
+[pathName, baseName, extension] = fileparts(fileName);
+switch lower(extension)
+    case '.ps'
+        if ~verLessThan('matlab', '9.8')
+            warning('tapas:physio:PostScriptNotSupported', ...
+                ['PostScript export is no longer supported by this ' ...
+                'MATLAB release. Saving the report as PDF instead.']);
+            fileName = fullfile(pathName, [baseName '.pdf']);
+            export_to_pdf(figHandles, fileName, appendToExisting);
+        else
+            export_to_postscript(figHandles, fileName, appendToExisting);
+        end
+    case '.pdf'
+        if ~verLessThan('matlab', '9.8')
+            export_to_pdf(figHandles, fileName, appendToExisting);
+        else
+            warning('tapas:physio:PdfNotSupported', ...
+                ['Multipage PDF export requires MATLAB R2020a or ' ...
+                'newer. Saving the report as PostScript instead.']);
+            fileName = fullfile(pathName, [baseName '.ps']);
+            export_to_postscript(figHandles, fileName, appendToExisting);
+        end
+    otherwise
+        error('tapas_physio:UnsupportedMultipageFormat', ...
+            'Multipage figure export does not support extension: %s', ...
+            extension);
+end
+end
+
+function export_to_pdf(figHandles, fileName, appendToExisting)
+for k = 1:numel(figHandles)
+    doAppend = appendToExisting || k > 1;
+    exportgraphics(figHandles(k), fileName, 'Append', doAppend);
+end
+end
+
+function export_to_postscript(figHandles, fileName, appendToExisting)
+if ~appendToExisting && isfile(fileName)
+    delete(fileName);
+end
+try % Level 2 PostScript
+    for k = 1:numel(figHandles)
+        print(figHandles(k), '-dpsc2', '-append', fileName); %#ok<PRINTPS4>
+    end
+catch
+    if isfile(fileName)
+        delete(fileName);
+    end
+    for k = 1:numel(figHandles)
+        print(figHandles(k), '-dpsc', '-append', fileName); %#ok<PRINTPS2>
+    end
+end
+end

--- a/code/plot/tapas_physio_print_figs_to_file.m
+++ b/code/plot/tapas_physio_print_figs_to_file.m
@@ -39,32 +39,9 @@ if ~isfield(verbose, 'fig_handles') || numel(verbose.fig_handles) == 0 || ...
 else
     [pfx, fn, sfx] = fileparts(verbose.fig_output_file);
     switch sfx
-        case '.ps'
-            % exportgraphics was introduced in MATLAB R2020a (version 9.8).
-            if ~verLessThan('matlab', '9.8')
-                warning('tapas:physio:PostScriptNotSupported', ...
-                    ['PostScript export is no longer supported by this ' ...
-                    'MATLAB release. Saving the report as PDF instead.']);
-                verbose.fig_output_file = fullfile(pfx, [fn '.pdf']);
-                export_figures_to_pdf(verbose.fig_handles, ...
-                    verbose.fig_output_file);
-            else
-                export_figures_to_postscript(verbose.fig_handles, ...
-                    verbose.fig_output_file);
-            end
-        case '.pdf'
-            % exportgraphics was introduced in MATLAB R2020a (version 9.8).
-            if ~verLessThan('matlab', '9.8')
-                export_figures_to_pdf(verbose.fig_handles, ...
-                    verbose.fig_output_file);
-            else
-                warning('tapas:physio:PdfNotSupported', ...
-                    ['Multipage PDF export requires MATLAB R2020a or ' ...
-                    'newer. Saving the report as PostScript instead.']);
-                verbose.fig_output_file = fullfile(pfx, [fn '.ps']);
-                export_figures_to_postscript(verbose.fig_handles, ...
-                    verbose.fig_output_file);
-            end
+        case {'.ps', '.pdf'}
+            verbose.fig_output_file = tapas_physio_export_figures( ...
+                verbose.fig_handles, verbose.fig_output_file, false);
         case '.fig'
             for k=1:numel(verbose.fig_handles)
                 saveas(verbose.fig_handles(k), fullfile(pfx,[fn sprintf('_%02d', k) sfx]));
@@ -85,27 +62,6 @@ else
             for k=1:numel(verbose.fig_handles)
                 print(verbose.fig_handles(k),printFormat,fullfile(pfx,[fn sprintf('_%02d', k) sfx]));
             end
-    end
-end
-end
-
-function export_figures_to_pdf(figHandles, fileName)
-for k = 1:numel(figHandles)
-    exportgraphics(figHandles(k), fileName, 'Append', k > 1);
-end
-end
-
-function export_figures_to_postscript(figHandles, fileName)
-try % Level 2 PostScript
-    for k = 1:numel(figHandles)
-        print(figHandles(k), '-dpsc2', '-append', fileName); %#ok<PRINTPS4>
-    end
-catch
-    if isfile(fileName)
-        delete(fileName);
-    end
-    for k = 1:numel(figHandles)
-        print(figHandles(k), '-dpsc', '-append', fileName); %#ok<PRINTPS2>
     end
 end
 end

--- a/tests/unit/assess/tapas_physio_print_report_test.m
+++ b/tests/unit/assess/tapas_physio_print_report_test.m
@@ -1,0 +1,46 @@
+classdef tapas_physio_print_report_test < matlab.unittest.TestCase
+    % Tests extension-aware contrast report printing.
+
+    methods (TestMethodSetup)
+        function createGraphicsFigure(testCase)
+            graphicsFigure = figure('Visible', 'off', 'Tag', 'Graphics');
+            graphicsAxes = axes('Parent', graphicsFigure);
+            plot(graphicsAxes, 1:3);
+            testCase.addTeardown(@() close(graphicsFigure));
+        end
+    end
+
+    methods (Test)
+        function testExtensionlessReportDefaultsToPdf(testCase)
+            outputFolder = testCase.createTemporaryFolder();
+            requestedFile = fullfile(outputFolder, 'report');
+
+            fileReport = tapas_physio_print_report(requestedFile);
+
+            testCase.verifyEqual(fileReport, [requestedFile '.pdf']);
+            testCase.verifyTrue(isfile(fileReport));
+        end
+
+        function testPdfPagesAreAppended(testCase)
+            outputFolder = testCase.createTemporaryFolder();
+            requestedFile = fullfile(outputFolder, 'report.pdf');
+            tapas_physio_print_report(requestedFile);
+            initialFile = dir(requestedFile);
+
+            fileReport = tapas_physio_print_report(requestedFile);
+            appendedFile = dir(requestedFile);
+
+            testCase.verifyEqual(fileReport, requestedFile);
+            testCase.verifyGreaterThan(appendedFile.bytes, initialFile.bytes);
+        end
+
+        function testUnsupportedExtensionErrors(testCase)
+            outputFolder = testCase.createTemporaryFolder();
+            requestedFile = fullfile(outputFolder, 'report.unsupported');
+
+            testCase.verifyError( ...
+                @() tapas_physio_print_report(requestedFile), ...
+                'tapas_physio:UnsupportedPrintFormat');
+        end
+    end
+end

--- a/tests/unit/plot/tapas_physio_export_figures_test.m
+++ b/tests/unit/plot/tapas_physio_export_figures_test.m
@@ -1,0 +1,42 @@
+classdef tapas_physio_export_figures_test < matlab.unittest.TestCase
+    % Tests the shared multipage figure exporter.
+
+    methods (Test)
+        function testReplacesExistingPdfByDefault(testCase)
+            outputFolder = testCase.createTemporaryFolder();
+            fileName = fullfile(outputFolder, 'report.pdf');
+            firstFigure = create_figure(1:3);
+            secondFigure = create_figure(3:-1:1);
+            testCase.addTeardown(@() close([firstFigure secondFigure]));
+            tapas_physio_export_figures(firstFigure, fileName);
+            firstFile = dir(fileName);
+
+            tapas_physio_export_figures(secondFigure, fileName);
+            replacedFile = dir(fileName);
+
+            testCase.verifyTrue(isfile(fileName));
+            testCase.verifyLessThanOrEqual( ...
+                replacedFile.bytes, 2 * firstFile.bytes);
+        end
+
+        function testAppendsToExistingPdfWhenRequested(testCase)
+            outputFolder = testCase.createTemporaryFolder();
+            fileName = fullfile(outputFolder, 'report.pdf');
+            graphicsFigure = create_figure(1:3);
+            testCase.addTeardown(@() close(graphicsFigure));
+            tapas_physio_export_figures(graphicsFigure, fileName);
+            initialFile = dir(fileName);
+
+            tapas_physio_export_figures(graphicsFigure, fileName, true);
+            appendedFile = dir(fileName);
+
+            testCase.verifyGreaterThan(appendedFile.bytes, initialFile.bytes);
+        end
+    end
+end
+
+function graphicsFigure = create_figure(plotData)
+graphicsFigure = figure('Visible', 'off');
+graphicsAxes = axes('Parent', graphicsFigure);
+plot(graphicsAxes, plotData);
+end


### PR DESCRIPTION
## What changed

- Default PhysIO contrast reports to PDF instead of PostScript.
- Preserve and honor the extension supplied in `fileReport`.
- Share multipage PDF/PostScript handling between normal PhysIO diagnostic figures and SPM contrast reports through `tapas_physio_export_figures`.
- Explicitly resolve the SPM `Graphics` figure before exporting contrast reports.
- Preserve explicit PostScript requests and the older-MATLAB fallback.
- Add regression tests for the shared exporter and the SPM report path.

## Why

PR #46 modernized PhysIO's normal diagnostic-figure export, but contrast reports followed a separate path through `tapas_physio_overlay_contrasts` and `spm_print`. That path discarded the requested extension and inherited SPM's global PostScript default, causing current MATLAB releases to attempt the unsupported `psc2` device.

`spm_print` can create a PDF, but its append option is supported only for full-page PostScript. The shared exporter therefore uses `exportgraphics` for multipage PDFs while still targeting the figure returned by `spm_figure('FindWin', 'Graphics')`.

Fixes #50.

## Validation

- 7/7 print-related unit tests passed across the shared exporter and both callers.
- MATLAB Code Analyzer reports no issues for the new shared exporter, SPM report helper, or their tests.
- Real Lewis et al. OpenNeuro ds004645 `sub-01/run-01` validation passed using the completed GLM: Cardiac and RespiratoryVolumePerTime SPM reports were exported into one 330,460-byte PDF.
- The Lewis validation PDF was independently verified to contain exactly two pages.
- No `psc2` error occurred with the proposed branch active.

The wider local unit run was affected by the configured SPM toolbox junction exposing a second PhysIO installation; the focused tests and real-data validation above used the proposed branch explicitly.
